### PR TITLE
Add a simple/advanced toggle

### DIFF
--- a/src/component/replace/index.tsx
+++ b/src/component/replace/index.tsx
@@ -16,7 +16,7 @@ interface ReplaceProps {
 }
 
 function Replace( props: ReplaceProps ): JSX.Element {
-	const { disabled, replacement, setReplace } = props;
+	const { disabled, replacement, setReplace, placeholder } = props;
 	const [ searchFlags, setFlags ] = useState( 'single' );
 	const value = {
 		id: 'replace',
@@ -25,7 +25,7 @@ function Replace( props: ReplaceProps ): JSX.Element {
 		placeholder:
 			searchFlags === 'remove'
 				? __( 'Matched values will be removed', 'search-regex' )
-				: __( 'Enter replacement value', 'search-regex' ),
+				: placeholder ?? __( 'Enter replacement value', 'search-regex' ),
 		name: 'replace',
 		onChange: ( ev: ChangeEvent< HTMLInputElement | HTMLTextAreaElement > ) => {
 			setReplace( { replacement: ev.target.value } );

--- a/src/component/search/index.tsx
+++ b/src/component/search/index.tsx
@@ -8,10 +8,20 @@ interface SearchProps {
 	onChange: ( value: string ) => void;
 	className?: string;
 	multiline?: boolean;
+	placeholder?: string;
+	multilinePlaceholder?: string;
 }
 
 function Search( props: SearchProps ): JSX.Element {
-	const { value, onChange, disabled = false, multiline = false, className } = props;
+	const {
+		value,
+		onChange,
+		disabled = false,
+		multiline = false,
+		className,
+		placeholder,
+		multilinePlaceholder,
+	} = props;
 
 	if ( multiline ) {
 		return (
@@ -24,7 +34,9 @@ function Search( props: SearchProps ): JSX.Element {
 				onChange={ ( ev: ChangeEvent< HTMLTextAreaElement > ) => onChange( ev.target.value ) }
 				disabled={ disabled }
 				className={ className }
-				placeholder={ __( 'Enter search phrase', 'search-regex' ) }
+				placeholder={
+					multilinePlaceholder ?? __( 'Enter search phrase', 'search-regex' )
+				}
 			/>
 		);
 	}
@@ -37,7 +49,10 @@ function Search( props: SearchProps ): JSX.Element {
 			disabled={ disabled }
 			onChange={ ( ev: ChangeEvent< HTMLInputElement > ) => onChange( ev.target.value ) }
 			className={ className }
-			placeholder={ __( 'Optional global search phrase. Leave blank to use filters only.', 'search-regex' ) }
+			placeholder={
+				placeholder ??
+				__( 'Optional global search phrase. Leave blank to use filters only.', 'search-regex' )
+			}
 		/>
 	);
 }

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -299,8 +299,13 @@ export type PresetUploadResponse = z.infer< typeof presetUploadResponseSchema >;
  */
 export const settingsValuesSchema = z.object( {
 	support: z.boolean(),
-	defaultPreset: z.string(), // Preset ID is a string (hex format)
 	rest_api: z.number(),
+	// Startup behaviour for the UI. "advanced" preserves existing behaviour
+	// and matches the current default UI.
+	startupMode: z.enum( [ 'simple', 'advanced', 'preset' ] ),
+	// When startupMode is "preset" this contains the preset ID. For other
+	// modes this may be an empty string or undefined.
+	startupPreset: z.string().optional(),
 	update_notice: z.union( [ z.string(), z.literal( false ) ] ).optional(),
 } );
 

--- a/src/page/home/style.scss
+++ b/src/page/home/style.scss
@@ -1,5 +1,17 @@
 @use "../../global" as *;
 
+.searchregex-header {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 8px;
+	margin-bottom: 1rem;
+
+	.wp-heading-inline {
+		padding: 9px 0;
+	}
+}
+
 /**
  * Delete button on options page
  */

--- a/src/page/search-replace/search-actions.tsx
+++ b/src/page/search-replace/search-actions.tsx
@@ -71,8 +71,11 @@ function SearchActions() {
 	const setIsSaving = useSearchStore( ( state ) => state.setIsSaving );
 	const setCanCancel = useSearchStore( ( state ) => state.setCanCancel );
 	const setReplaceAll = useSearchStore( ( state ) => state.setReplaceAll );
+	const mode = useSearchStore( ( state ) => state.mode );
 
-	const { action = '', actionOption = {}, replacement = null } = search;
+	const { action: rawAction = '', actionOption = {}, replacement = null } = search;
+	const effectiveAction = mode === 'simple' ? 'replace' : rawAction;
+	const effectiveActionOption = mode === 'simple' ? {} : ( actionOption as ActionOption );
 	const performMutation = useSearch();
 
 	const handlePerform = () => {
@@ -81,9 +84,18 @@ function SearchActions() {
 		setReplaceAll( true );
 		setStatus( STATUS_IN_PROGRESS );
 
+		const payload =
+			mode === 'simple'
+				? {
+					...search,
+					action: 'replace',
+					actionOption: {},
+				}
+				: search;
+
 		performMutation.mutate(
 			{
-				...search,
+				...payload,
 				page: 0,
 				save: true,
 			},
@@ -122,17 +134,17 @@ function SearchActions() {
 				{ resultsDirty ? __( 'Refresh', 'search-regex' ) : __( 'Search', 'search-regex' ) }
 			</Button>
 
-			{ action !== '' && (
+			{ effectiveAction !== '' && (
 				<Button
 					isDestructive
 					disabled={
-						! isPerformReady( action, actionOption, replacement ) ||
+						! isPerformReady( effectiveAction, effectiveActionOption, replacement ) ||
 						status === STATUS_IN_PROGRESS ||
 						isSaving
 					}
 					onClick={ handlePerform }
 				>
-					{ getPerformButton( action ) }
+					{ getPerformButton( effectiveAction ) }
 				</Button>
 			) }
 

--- a/src/page/search-replace/search-form/index.tsx
+++ b/src/page/search-replace/search-form/index.tsx
@@ -12,6 +12,7 @@ function SearchForm() {
 	const setSearch = useSearchStore( ( state ) => state.setSearch );
 	const replaceAll = useSearchStore( ( state ) => state.replaceAll );
 	const status = useSearchStore( ( state ) => state.status );
+	const mode = useSearchStore( ( state ) => state.mode );
 	const currentPreset = usePresetStore( ( state ) => state.currentPreset );
 
 	const headerClass = getHeaderClass( currentPreset ? currentPreset.tags : [] );
@@ -19,12 +20,14 @@ function SearchForm() {
 	return (
 		<table>
 			<tbody>
-				<tr className={ clsx( headerClass ) }>
-					<th>{ __( 'Preset', 'search-regex' ) }</th>
-					<td>
-						<Presets />
-					</td>
-				</tr>
+				{ mode === 'advanced' && (
+					<tr className={ clsx( headerClass ) }>
+						<th>{ __( 'Preset', 'search-regex' ) }</th>
+						<td>
+							<Presets />
+						</td>
+					</tr>
+				) }
 
 				<Form
 					search={ search as any }


### PR DESCRIPTION
A a simple/advanced mode. This is shown at the top of the page and switches between advanced mode (previous), and simple mode (just search/replace)

<img width="814" height="426" alt="image" src="https://github.com/user-attachments/assets/1e31a3a9-f38e-4513-a356-7045c894b960" />
