### PR TITLE
Fix missing source param from column context

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"plugin": "pnpm build && rm -rf release && mkdir -p release/search-regex && cp -R search-regex.php search-regex-loader.php changelog.txt readme.txt build license.txt includes release/search-regex",
 		"plugin:zip": "pnpm plugin && cd release && zip -r search-regex.zip search-regex",
 		"release": "pnpm plugin:zip && release-it",
-		"release:svn": "pnpm plugin:zip && cd release && unzip search-regex.zip && cd .. && rm release/search-regex.zip && dev/svn.sh $npm_package_version",
+		"release:svn": "pnpm plugin && dev/svn.sh $npm_package_version",
 		"start": "wp-scripts start",
 		"test": "pnpm test:php && pnpm test:js && pnpm test:integration",
 		"test:integration": "wp-env run cli --env-cwd=wp-content/plugins/search-regex composer run test-integration",

--- a/src/component/result/column/context-item.tsx
+++ b/src/component/result/column/context-item.tsx
@@ -28,7 +28,7 @@ function ContextItem( props: ContextItemProps ): JSX.Element {
 	function onSave( toggle: () => void ): void {
 		toggle();
 		save( null );
-		saveRowMutation.mutate( { replacement, rowId: String( rowId ) } );
+		saveRowMutation.mutate( { replacement: { ...replacement, source }, rowId: String( rowId ) } );
 	}
 
 	return (

--- a/src/component/result/context-type/index.tsx
+++ b/src/component/result/context-type/index.tsx
@@ -95,6 +95,7 @@ function ContextType( props: ContextTypeProps ): JSX.Element {
 	}
 
 	if ( type === 'string' ) {
+		const sourceValue = ( schema as any ).source || '';
 		return (
 			<HighlightMatches
 				source={ context.context || '' }
@@ -103,7 +104,7 @@ function ContextType( props: ContextTypeProps ): JSX.Element {
 				count={ context.match_count || 0 }
 				rowId={ Number( rowId ) }
 				column={ column.column_id }
-				schema={ { name: '', type: '', columns: [ schema ] } as Schema }
+				schema={ { name: '', type: sourceValue, columns: [ schema ], source: sourceValue } as Schema }
 				{ ...( className !== undefined ? { className } : {} ) }
 			/>
 		);

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -166,7 +166,7 @@ export interface Filter {
  */
 export interface ModifyStringColumn {
 	column: string;
-	source?: string;
+	source: string;
 	operation: 'set' | 'replace' | 'regex';
 	setValue?: string;
 	replaceValue?: string;
@@ -179,7 +179,7 @@ export interface ModifyStringColumn {
  */
 export interface ModifyDateColumn {
 	column: string;
-	source?: string;
+	source: string;
 	operation: 'set' | 'increment' | 'decrement';
 	value: string | Date;
 	unit?: 'second' | 'hour' | 'day' | 'month' | 'year';
@@ -190,7 +190,7 @@ export interface ModifyDateColumn {
  */
 export interface ModifyIntegerColumn {
 	column: string;
-	source?: string;
+	source: string;
 	operation: 'set' | 'increment' | 'decrement';
 	value: string;
 }
@@ -200,7 +200,7 @@ export interface ModifyIntegerColumn {
  */
 export interface ModifyMemberColumn {
 	column: string;
-	source?: string;
+	source: string;
 	operation: 'set' | 'include' | 'exclude';
 	values: string[];
 	label?: string | string[];


### PR DESCRIPTION
The source param was marked as optional and not sent, when in fact it is required and needs to be sent.