### PR TITLE
Fix export action crash after successful search

### DIFF
--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -6,11 +6,13 @@ import { useMessageStore } from '../stores/message-store';
 import { useSearchStore } from '../stores/search-store';
 import {
 	searchResponseSchema,
+	exportActionResponseSchema,
 	deleteRowResponseSchema,
 	loadRowResponseSchema,
 	saveRowResponseSchema,
 	sourceCompleteResponseSchema,
 	type SearchResponse,
+	type ExportActionResponse,
 	type DeleteRowResponse,
 	type LoadRowResponse,
 	type SaveRowResponse,
@@ -24,13 +26,19 @@ interface SearchParams extends SearchValues {
 	limit?: number;
 }
 
+type SearchMutationResponse = SearchResponse | ExportActionResponse;
+
 export function useSearch() {
 	const addError = useMessageStore( ( state ) => state.addError );
 
-	return useMutation< SearchResponse, Error, SearchParams >( {
+	return useMutation< SearchMutationResponse, Error, SearchParams >( {
 		mutationFn: async ( searchParams ) => {
 			const response = await apiFetch( postApiRequest( 'search-regex/v1/search', searchParams ) );
-			// Validate and parse response with Zod
+
+			if ( searchParams.action === 'export' && searchParams.save ) {
+				return exportActionResponseSchema.parse( response );
+			}
+
 			return searchResponseSchema.parse( response );
 		},
 		onError: ( error ) => {

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -104,36 +104,32 @@ const contextSchema: z.ZodType< any > = z.union( [
 		.passthrough(), // Allow any additional fields
 ] );
 
-/**
- * Search API response schema
- */
-export const searchResponseSchema = z.object( {
-	results: z.array(
+const searchResultSchema = z.object( {
+	row_id: z.union( [ z.string(), z.number() ] ).transform( ( val ) => String( val ) ),
+	match_count: z.number().optional(),
+	source_name: z.string(),
+	source_type: z.string(),
+	title: z.string(),
+	actions: z.unknown(),
+	columns: z.array(
 		z.object( {
-			row_id: z.union( [ z.string(), z.number() ] ).transform( ( val ) => String( val ) ),
+			column_id: z.string(),
+			column_label: z.string().optional(),
+			contexts: z.array( contextSchema ),
+			context_count: z.number().optional(),
 			match_count: z.number().optional(),
-			source_name: z.string(),
-			source_type: z.string(),
-			title: z.string(),
-			actions: z.unknown(),
-			columns: z.array(
-				z.object( {
-					column_id: z.string(),
-					column_label: z.string().optional(),
-					contexts: z.array( contextSchema ),
-					context_count: z.number().optional(),
-					match_count: z.number().optional(),
-				} )
-			),
 		} )
 	),
-	progress: z.object( {
-		current: z.number().optional(),
-		rows: z.number().optional(),
-		next: z.union( [ z.boolean(), z.number() ] ),
-		previous: z.union( [ z.boolean(), z.number() ] ).optional(),
-	} ),
-	totals: z.object( {
+} );
+
+const searchProgressSchema = z.object( {
+	current: z.number().optional(),
+	rows: z.number().optional(),
+	next: z.union( [ z.boolean(), z.number() ] ),
+	previous: z.union( [ z.boolean(), z.number() ] ).optional(),
+} );
+
+const searchTotalsSchema = z.object( {
 		matched_rows: z.number(),
 		rows: z.number(),
 		custom: z
@@ -144,11 +140,32 @@ export const searchResponseSchema = z.object( {
 				} )
 			)
 			.optional(),
-	} ),
+} );
+
+/**
+ * Search API response schema
+ */
+export const searchResponseSchema = z.object( {
+	results: z.array( searchResultSchema ),
+	progress: searchProgressSchema,
+	totals: searchTotalsSchema,
 	status: z.string().optional(),
 } );
 
 export type SearchResponse = z.infer< typeof searchResponseSchema >;
+
+/**
+ * Export action response schema
+ * The export action returns formatted rows (string for CSV/SQL, object for JSON).
+ */
+export const exportActionResponseSchema = z.object( {
+	results: z.array( z.union( [ z.string(), z.record( z.string(), z.unknown() ) ] ) ),
+	progress: searchProgressSchema,
+	totals: searchTotalsSchema,
+	status: z.string().optional(),
+} );
+
+export type ExportActionResponse = z.infer< typeof exportActionResponseSchema >;
 
 /**
  * Delete row response schema

--- a/src/page/search-replace/search-actions.tsx
+++ b/src/page/search-replace/search-actions.tsx
@@ -8,6 +8,8 @@ import {
 	convertToResults,
 } from '../../stores/search-store';
 import { useSearch } from '../../hooks/use-search';
+import { saveExport } from '../../lib/export';
+import type { SearchResponse } from '../../lib/api-schemas';
 
 interface ActionOption {
 	length?: number;
@@ -111,20 +113,32 @@ function SearchActions() {
 			},
 			{
 				onSuccess: ( data ) => {
+					if ( effectiveAction === 'export' ) {
+						const exportFormat = payload.actionOption?.format ?? 'json';
+						saveExport( data.results as unknown[], exportFormat );
+						setStatus( STATUS_COMPLETE );
+						setIsSaving( false );
+						setCanCancel( false );
+						setReplaceAll( false );
+						return;
+					}
+
+					const searchData = data as SearchResponse;
+
 					// Convert API results (number row_id) to Result[] (string row_id)
-					setResults( convertToResults( data.results ) );
-					setTotals( convertToSearchTotals( data.totals ) );
-					setProgress( convertToSearchProgress( data.progress ) );
+					setResults( convertToResults( searchData.results ) );
+					setTotals( convertToSearchTotals( searchData.totals ) );
+					setProgress( convertToSearchProgress( searchData.progress ) );
 
 					// For regex searches, keep status as IN_PROGRESS if there are more pages
 					// The sliding window in ReplaceProgress will handle the rest
-					const hasMorePages = data.progress.next !== false;
+					const hasMorePages = searchData.progress.next !== false;
 					if ( hasMorePages ) {
 						// Keep status as IN_PROGRESS so ReplaceProgress sliding window continues
 						setStatus( STATUS_IN_PROGRESS );
 					} else {
 						// All done - mark as complete and clean up flags
-						setStatus( data.status ?? STATUS_COMPLETE );
+						setStatus( searchData.status ?? STATUS_COMPLETE );
 						setIsSaving( false );
 						setCanCancel( false );
 						setReplaceAll( false );


### PR DESCRIPTION
Summary: export can fail after successful search with invalid_type at results[n] (expected object, received string). Cause: export responses (save=true, action=export) return formatted rows, but frontend parsed/handled them as normal search result objects. Changes: add exportActionResponseSchema, parse export mutations with it in useSearch, and in search-actions handle export via saveExport without convertToResults. Regression introduced in 903c324 (TypeScript/Zod migration). User impact: search still works, export now downloads instead of showing runtime error modal.