### PR TITLE
fix: use LEFT JOIN for tag/category exclude filters so untagged posts…

### DIFF
--- a/includes/filter/type/class-filter-member.php
+++ b/includes/filter/type/class-filter-member.php
@@ -91,6 +91,10 @@ class Filter_Member extends Filter_Type {
 		$select = new Sql\Select\Select_Column( $this->schema );
 
 		if ( $this->join ) {
+			if ( $this->logic === 'exclude' ) {
+				$this->join->set_outer_join();
+			}
+
 			$query->add_join( $this->join );
 		}
 

--- a/includes/sql/join/class-join.php
+++ b/includes/sql/join/class-join.php
@@ -14,6 +14,11 @@ abstract class Join {
 	protected bool $is_matching = true;
 
 	/**
+	 * Use a LEFT JOIN instead of INNER JOIN (needed for exclude logic to include untagged posts)
+	 */
+	protected bool $is_outer_join = false;
+
+	/**
 	 * Column to join on
 	 */
 	protected string $column;
@@ -109,6 +114,15 @@ abstract class Join {
 	 */
 	public function set_non_matching() {
 		$this->is_matching = false;
+	}
+
+	/**
+	 * Use a LEFT JOIN so posts with no matching terms are included in exclude queries
+	 *
+	 * @return void
+	 */
+	public function set_outer_join(): void {
+		$this->is_outer_join = true;
 	}
 
 	/**

--- a/includes/sql/join/class-term.php
+++ b/includes/sql/join/class-term.php
@@ -19,8 +19,18 @@ class Term extends Join {
 	}
 
 	public function get_where() {
+		$taxonomy_col = new Sql\Select\Select( Sql\Value::column( 'tt' ), Sql\Value::column( 'taxonomy' ) );
+
 		if ( $this->is_matching ) {
-			return new Sql\Where\Where_String( new Sql\Select\Select( Sql\Value::column( 'tt' ), Sql\Value::column( 'taxonomy' ) ), '=', $this->column );
+			return new Sql\Where\Where_String( $taxonomy_col, '=', $this->column );
+		}
+
+		if ( $this->is_outer_join ) {
+			// LEFT JOIN: posts with no tags have NULL taxonomy, so allow either the taxonomy or NULL
+			return new Sql\Where\Where_Or( [
+				new Sql\Where\Where_String( $taxonomy_col, '=', $this->column ),
+				new Sql\Where\Where_Null( $taxonomy_col, 'empty' ),
+			] );
 		}
 
 		return false;
@@ -39,8 +49,12 @@ class Term extends Join {
 	public function get_from() {
 		global $wpdb;
 
-		if ( $this->is_matching ) {
-			return new Sql\From( Sql\Value::safe_raw( sprintf( 'INNER JOIN %sterm_relationships AS tr ON (%s.ID = tr.object_id) INNER JOIN %sterm_taxonomy AS tt ON tt.term_taxonomy_id=tr.term_taxonomy_id', $wpdb->prefix, $wpdb->posts, $wpdb->prefix ) ) );
+		if ( $this->is_matching || $this->is_outer_join ) {
+			$join_type = $this->is_outer_join ? 'LEFT JOIN' : 'INNER JOIN';
+			return new Sql\From( Sql\Value::safe_raw( sprintf(
+				'%s %sterm_relationships AS tr ON (%s.ID = tr.object_id) %s %sterm_taxonomy AS tt ON tt.term_taxonomy_id=tr.term_taxonomy_id',
+				$join_type, $wpdb->prefix, $wpdb->posts, $join_type, $wpdb->prefix
+			) ) );
 		}
 
 		return false;


### PR DESCRIPTION
John, this addresses issue #196 and adds some saftey nets around the JOINs.

When excluding by tag (e.g. "post_tag excludes any [tag X]"), posts with no tags at all were being silently dropped from results. The query used INNER JOIN on `wp_term_relationships`, so posts with no tag relationships were removed before WHERE could test them — even though the WHERE clause already had `(NOT IN (...) OR tr.term_taxonomy_id IS NULL)`.

Three small changes across the SQL layer:

- `class-join.php` — added `$is_outer_join` property and `set_outer_join()` method to the base class
- `class-term.php` — when `is_outer_join` is set, uses LEFT JOIN and allows `NULL` taxonomy in the WHERE condition so posts with no tag relationships pass through
- `class-filter-member.php` — calls `set_outer_join()` on the join when the filter logic is `'exclude'`

The fix matches what the issue diagnosis describes. I didn't add an automated test since this needs a live database to verify the join behaviour, but the logic follows directly from the reported SQL.

Fixes #196.

(full disclosure, I used AI help with the testing and tweaks - Christopher)